### PR TITLE
Fix UI glitch in Voice Description

### DIFF
--- a/src/vst/controls.h
+++ b/src/vst/controls.h
@@ -426,6 +426,7 @@ class ModelVoiceDescription : public VSTGUI::CScrollView {
     voice_description_->setLineLayout(CMultiLineTextLabel::LineLayout::wrap);
     voice_description_->setTextInset(CPoint(0, 2));
     addView(voice_description_);
+
     AdjustVoiceDescriptionPosition();
   }
 
@@ -474,6 +475,10 @@ class ModelVoiceDescription : public VSTGUI::CScrollView {
   friend class Editor;
 
   void AdjustVoiceDescriptionPosition() {
+    auto vsb = getVerticalScrollbar();
+    const auto prev_scroll_pos = vsb->getValue();
+    resetScrollOffset();
+
     auto y =
         model_description_->getText() == nullptr
             ? 0
@@ -488,6 +493,12 @@ class ModelVoiceDescription : public VSTGUI::CScrollView {
     auto container_size = getContainerSize();
     container_size.setHeight(y);
     setContainerSize(container_size);
+
+    vsb->setValue(prev_scroll_pos);
+    vsb->bounceValue();
+    vsb->onVisualChange();
+    vsb->invalid();
+    valueChanged(vsb);
 
     setDirty();
     Invalid();

--- a/src/vst/editor.cc
+++ b/src/vst/editor.cc
@@ -244,10 +244,10 @@ void Editor::SyncValue(const ParamID param_id, const float plain_value) {
     auto* const voice_control =
         controls_.at(static_cast<int>(ParameterID::kVoice));
     const auto voice_id = voice_control->getValue();
+    control->setValue(plain_value);
     if (voice_id > 0 && voice_id == static_cast<int>(voice_control->getMax())) {
       SyncVoiceMorphingDescription();
     }
-    control->setValue(plain_value);
     SyncVoiceMorphingSliders();
   } else {
     control->setValue(plain_value);


### PR DESCRIPTION
真ん中の列をスクロールした状態で話者モーフィングの話者数が変動したときの挙動を修正しました。

スクロールした状態でコンテナサイズの変更を行うとおかしくなるっぽかったので、一度スクロールをリセットしてからコンテナサイズを変更し、元のスクロール位置に戻すという処理にしています。
