### PR TITLE
Add macOS (Apple Silicon) build via a dlopen'd Beatrice runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,13 @@ endif()
 
 project(beatrice VERSION ${major_version}.${minor_version}.${patch_version})
 option(BEATRICE_DEV_VERSION "Development version" ON)
+option(BEATRICE_ENABLE_AUV2 "Build a macOS AUv2 component wrapper around the VST3 plug-in" OFF)
+option(BEATRICE_ENABLE_BENCHMARKS "Build local processor benchmark tools" OFF)
+option(BEATRICE_ENABLE_LOADER_LOG "Write macOS runtime loader diagnostics to /tmp/beatrice-vst-loader.log" OFF)
+set(BEATRICE_MAC_RUNTIME "" CACHE FILEPATH "Path to the macOS Beatrice runtime bundle, e.g. beatrice/v20rc0.abi3.so from VCClient")
+if(APPLE AND BEATRICE_ENABLE_AUV2)
+    enable_language(OBJCXX)
+endif()
 if(BEATRICE_DEV_VERSION)
     set(full_version_str ${major_version}.${minor_version}.${patch_version}${prerelease_version}+dev.${GIT_HASH})
 else()
@@ -50,34 +57,46 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>")
 set(SMTG_ENABLE_VST3_HOSTING_EXAMPLES 0)
 set(SMTG_ENABLE_VST3_PLUGIN_EXAMPLES 0)
 set(SMTG_ENABLE_VSTGUI_SUPPORT 1)
+if(APPLE)
+    set(SMTG_CREATE_PLUGIN_LINK 0 CACHE BOOL "Do not auto-link build outputs into the user's VST3 folder" FORCE)
+endif()
 
 set(vst3sdk_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/vst3sdk)
 
 add_subdirectory(lib/vst3sdk)
+
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    foreach(vstgui_target vstgui vstgui_support)
+        if(TARGET ${vstgui_target})
+            target_compile_options(${vstgui_target}
+                PRIVATE -Wno-error=unused-but-set-variable
+                PRIVATE -Wno-error=deprecated-declarations
+            )
+        endif()
+    endforeach()
+endif()
 
 smtg_enable_vst3_sdk()
 
 configure_file(src/vst/metadata.h.in src/vst/metadata.h)
 set(SMTG_PACKAGE_ICON_PATH ${CMAKE_CURRENT_SOURCE_DIR}/resource/icon.ico)
 
-smtg_add_vst3plugin(${target}
+set(BEATRICE_COMMON_SOURCES
     src/common/parameter_schema.cc
     src/common/parameter_state.cc
     src/common/processor_core_0.cc
     src/common/processor_core_1.cc
     src/common/processor_core_2.cc
     src/common/processor_proxy.cc
+)
+
+smtg_add_vst3plugin(${target}
+    ${BEATRICE_COMMON_SOURCES}
     src/vst/controller.cc
     src/vst/editor.cc
     src/vst/factory.cc
     src/vst/parameter.cc
     src/vst/processor.cc
-)
-
-add_library(beatricelib STATIC IMPORTED)
-set_property(
-    TARGET beatricelib
-    PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/beatricelib/beatrice.lib
 )
 
 target_include_directories(${target}
@@ -87,17 +106,158 @@ target_include_directories(${target}
 )
 
 target_link_libraries(${target}
-    PRIVATE beatricelib
     PRIVATE sdk
     PRIVATE vstgui_support
 )
 
 if(SMTG_WIN)
+    add_library(beatricelib STATIC IMPORTED)
+    set_property(
+        TARGET beatricelib
+        PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/beatricelib/beatrice.lib
+    )
+    target_link_libraries(${target}
+        PRIVATE beatricelib
+    )
     target_sources(${target}
         PRIVATE resource/beatrice.rc
     )
+elseif(APPLE)
+    if(NOT BEATRICE_MAC_RUNTIME)
+        message(FATAL_ERROR "BEATRICE_MAC_RUNTIME is required on macOS. Pass the path to VCClient's beatrice/v20rc0.abi3.so.")
+    endif()
+    if(NOT EXISTS "${BEATRICE_MAC_RUNTIME}")
+        message(FATAL_ERROR "BEATRICE_MAC_RUNTIME does not exist: ${BEATRICE_MAC_RUNTIME}")
+    endif()
+    get_filename_component(BEATRICE_MAC_RUNTIME_FILENAME "${BEATRICE_MAC_RUNTIME}" NAME)
+    target_sources(${target}
+        PRIVATE src/common/beatricelib_dynamic_loader.cc
+    )
+	    target_compile_definitions(${target}
+	        PRIVATE BEATRICE_MAC_RUNTIME_FILENAME="${BEATRICE_MAC_RUNTIME_FILENAME}"
+	    )
+	    if(BEATRICE_ENABLE_LOADER_LOG)
+	        target_compile_definitions(${target}
+	            PRIVATE BEATRICE_ENABLE_LOADER_LOG=1
+	        )
+	    endif()
+    target_link_libraries(${target}
+        PRIVATE ${CMAKE_DL_LIBS}
+    )
+    add_custom_command(
+        TARGET ${target}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target}>/../Resources/beatrice"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${BEATRICE_MAC_RUNTIME}" "$<TARGET_FILE_DIR:${target}>/../Resources/beatrice/${BEATRICE_MAC_RUNTIME_FILENAME}"
+        COMMAND codesign --force --sign - "$<TARGET_FILE_DIR:${target}>/../Resources/beatrice/${BEATRICE_MAC_RUNTIME_FILENAME}"
+        COMMAND codesign --force --sign - "$<TARGET_FILE_DIR:${target}>/../.."
+        COMMENT "Copying Beatrice macOS runtime"
+    )
 else()
     message(WARNING "Unsupported platform")
+endif()
+
+if(BEATRICE_ENABLE_BENCHMARKS)
+    add_executable(beatrice_processor_bench
+        tools/bench_processor.cc
+        ${BEATRICE_COMMON_SOURCES}
+    )
+    target_include_directories(beatrice_processor_bench
+        PRIVATE src
+        PRIVATE lib
+    )
+    if(SMTG_WIN)
+        target_link_libraries(beatrice_processor_bench
+            PRIVATE beatricelib
+        )
+    elseif(APPLE)
+        target_sources(beatrice_processor_bench
+            PRIVATE src/common/beatricelib_dynamic_loader.cc
+        )
+	    target_compile_definitions(beatrice_processor_bench
+	        PRIVATE BEATRICE_MAC_RUNTIME_FILENAME="${BEATRICE_MAC_RUNTIME_FILENAME}"
+	    )
+	    if(BEATRICE_ENABLE_LOADER_LOG)
+	        target_compile_definitions(beatrice_processor_bench
+	            PRIVATE BEATRICE_ENABLE_LOADER_LOG=1
+	        )
+	    endif()
+        target_link_libraries(beatrice_processor_bench
+            PRIVATE ${CMAKE_DL_LIBS}
+        )
+    endif()
+endif()
+
+if(APPLE AND BEATRICE_ENABLE_AUV2)
+    if(NOT XCODE)
+        message(FATAL_ERROR "BEATRICE_ENABLE_AUV2 requires the Xcode CMake generator.")
+    endif()
+    if(NOT SMTG_COREAUDIO_SDK_PATH)
+        message(FATAL_ERROR "BEATRICE_ENABLE_AUV2 requires SMTG_COREAUDIO_SDK_PATH, e.g. a Steinberg-compatible external.apple.coreaudio checkout.")
+    endif()
+
+    set(auv2_target ${target}_au)
+    set(auv2_bundle_name Beatrice)
+    string(TIMESTAMP CocoaIdStamp "%Y%j%H%M%S")
+    string(MAKE_C_IDENTIFIER ${CocoaIdStamp} CocoaId)
+
+    add_library(${auv2_target} MODULE
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/aucocoaview.mm
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/aucocoaview.h
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/ausdk.mm
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/auwrapper.mm
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/auwrapper.h
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/NSDataIBStream.mm
+        ${public_sdk_SOURCE_DIR}/source/vst/auwrapper/NSDataIBStream.h
+    )
+    add_dependencies(${auv2_target} ${target})
+    smtg_target_setup_universal_binary(${auv2_target})
+    smtg_target_codesign(${auv2_target})
+    smtg_target_set_bundle(${auv2_target}
+        INFOPLIST ${CMAKE_CURRENT_SOURCE_DIR}/resource/au-info.plist
+        EXTENSION component
+    )
+    target_compile_features(${auv2_target}
+        PUBLIC cxx_std_17
+    )
+    target_compile_definitions(${auv2_target}
+        PRIVATE SMTG_AUCocoaUIBase_CLASS_NAME=SMTG_AUCocoaUIBase_${auv2_bundle_name}${CocoaId}
+        PRIVATE CA_USE_AUDIO_PLUGIN_ONLY=0
+    )
+    target_include_directories(${auv2_target}
+        PRIVATE "${SMTG_COREAUDIO_SDK_PATH}"
+        PRIVATE "${SMTG_COREAUDIO_SDK_PATH}/AudioUnits"
+        PRIVATE "${SMTG_COREAUDIO_SDK_PATH}/PublicUtility"
+    )
+    target_link_libraries(${auv2_target}
+        PRIVATE sdk_hosting
+        PRIVATE "-framework AudioUnit"
+        PRIVATE "-framework CoreMIDI"
+        PRIVATE "-framework AudioToolbox"
+        PRIVATE "-framework CoreFoundation"
+        PRIVATE "-framework Carbon"
+        PRIVATE "-framework Cocoa"
+        PRIVATE "-framework CoreAudio"
+    )
+
+    set(VST3_OUTPUT_DIR ${CMAKE_BINARY_DIR}/VST3)
+    set(outputdir ${VST3_OUTPUT_DIR}/$<CONFIG>)
+    set_target_properties(${auv2_target}
+        PROPERTIES
+            XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
+            XCODE_ATTRIBUTE_PRODUCT_NAME "${auv2_bundle_name}"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.prj-beatrice.beatrice.auv2"
+            LIBRARY_OUTPUT_DIRECTORY ${VST3_OUTPUT_DIR}
+    )
+    add_custom_command(
+        TARGET ${auv2_target}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${outputdir}/${auv2_bundle_name}.component/Contents/Resources"
+        COMMAND ${CMAKE_COMMAND} -E rm -f "${outputdir}/${auv2_bundle_name}.component/Contents/Resources/plugin.vst3"
+        COMMAND ${CMAKE_COMMAND} -E create_symlink "${outputdir}/$<TARGET_FILE_NAME:${target}>.vst3" "${outputdir}/${auv2_bundle_name}.component/Contents/Resources/plugin.vst3"
+        COMMAND codesign --force --sign - "${outputdir}/${auv2_bundle_name}.component"
+        COMMENT "Linking VST3 bundle into AUv2 wrapper"
+    )
 endif()
 
 # ----------------------------------------------------------------

--- a/resource/au-info.plist
+++ b/resource/au-info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>2.0.0</string>
+	<key>AudioComponents</key>
+	<array>
+		<dict>
+			<key>factoryFunction</key>
+			<string>AUWrapperFactory</string>
+			<key>description</key>
+			<string>Beatrice</string>
+			<key>manufacturer</key>
+			<string>PrBe</string>
+			<key>name</key>
+			<string>Project Beatrice: Beatrice</string>
+			<key>subtype</key>
+			<string>Brc2</string>
+			<key>type</key>
+			<string>aufx</string>
+			<key>version</key>
+			<integer>0x02000000</integer>
+		</dict>
+	</array>
+	<key>AudioUnit SupportedNumChannels</key>
+	<array>
+		<dict>
+			<key>Outputs</key>
+			<string>1</string>
+			<key>Inputs</key>
+			<string>1</string>
+		</dict>
+		<dict>
+			<key>Outputs</key>
+			<string>2</string>
+			<key>Inputs</key>
+			<string>2</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/src/common/beatricelib_dynamic_loader.cc
+++ b/src/common/beatricelib_dynamic_loader.cc
@@ -1,0 +1,450 @@
+// Copyright (c) 2024-2025 Project Beatrice and Contributors
+
+#include "beatricelib/beatrice.h"
+
+#ifndef __APPLE__
+#error "beatricelib_dynamic_loader.cc is only intended for macOS builds"
+#endif
+
+#include <dlfcn.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+#ifndef BEATRICE_MAC_RUNTIME_FILENAME
+#define BEATRICE_MAC_RUNTIME_FILENAME "beatrice_v20rc0.abi3.so"
+#endif
+
+#ifndef BEATRICE_MAC_PYTHON_RUNTIME
+#define BEATRICE_MAC_PYTHON_RUNTIME ""
+#endif
+
+#ifndef BEATRICE_ENABLE_LOADER_LOG
+#define BEATRICE_ENABLE_LOADER_LOG 0
+#endif
+
+namespace {
+
+void Log(const char* const format, ...) {
+#if BEATRICE_ENABLE_LOADER_LOG
+  if (FILE* const file = std::fopen("/tmp/beatrice-vst-loader.log", "a")) {
+    va_list args;
+    va_start(args, format);
+    std::vfprintf(file, format, args);
+    va_end(args);
+    std::fputc('\n', file);
+    std::fclose(file);
+  }
+#else
+  (void)format;
+#endif
+}
+
+[[noreturn]] void Fail(const std::string& message) {
+  Log("fatal: %s", message.c_str());
+  std::fprintf(stderr, "Beatrice runtime loader error: %s\n", message.c_str());
+  std::abort();
+}
+
+bool TryOpen(const char* path, const int flags, void** handle,
+             std::string& last_error) {
+  if (path == nullptr || path[0] == '\0') {
+    return false;
+  }
+  Log("dlopen try flags=0x%x path=%s", flags, path);
+  *handle = dlopen(path, flags);
+  if (*handle != nullptr) {
+    Log("dlopen ok path=%s handle=%p", path, *handle);
+    return true;
+  }
+  if (const char* error = dlerror()) {
+    last_error = error;
+    Log("dlopen fail path=%s error=%s", path, error);
+  } else {
+    Log("dlopen fail path=%s without dlerror", path);
+  }
+  return false;
+}
+
+bool LooksLikePythonSymbolError(const std::string_view error) {
+  return error.find("_Py") != std::string_view::npos ||
+         error.find("Py") != std::string_view::npos;
+}
+
+void* OpenPythonRuntime() {
+  const char* env_path = std::getenv("BEATRICE_MAC_PYTHON_RUNTIME");
+  const char* candidates[] = {
+      env_path,
+      BEATRICE_MAC_PYTHON_RUNTIME,
+      "@loader_path/../Resources/python/Python.framework/Python",
+      "@loader_path/../Resources/beatrice/Python.framework/Python",
+      "/opt/homebrew/Frameworks/Python.framework/Python",
+      "/Library/Frameworks/Python.framework/Python",
+      "/usr/local/Frameworks/Python.framework/Python",
+  };
+
+  std::string last_error;
+  void* handle = nullptr;
+  Log("opening Python runtime");
+  for (const char* path : candidates) {
+    if (TryOpen(path, RTLD_NOW | RTLD_GLOBAL, &handle, last_error)) {
+      return handle;
+    }
+  }
+  return nullptr;
+}
+
+void* OpenRuntime() {
+  Log("opening Beatrice runtime filename=%s", BEATRICE_MAC_RUNTIME_FILENAME);
+  std::string loader_path =
+      std::string("@loader_path/../Resources/beatrice/") +
+      BEATRICE_MAC_RUNTIME_FILENAME;
+  std::string sibling_path =
+      std::string("@loader_path/") + BEATRICE_MAC_RUNTIME_FILENAME;
+
+  const char* env_path = std::getenv("BEATRICE_MAC_RUNTIME");
+  const char* candidates[] = {
+      env_path,
+      loader_path.c_str(),
+      sibling_path.c_str(),
+  };
+
+  auto try_open_beatrice = [&candidates](std::string& last_error,
+                                         bool* python_symbol_error) -> void* {
+    void* handle = nullptr;
+    for (const char* path : candidates) {
+      if (TryOpen(path, RTLD_NOW | RTLD_LOCAL, &handle, last_error)) {
+        return handle;
+      }
+      if (LooksLikePythonSymbolError(last_error)) {
+        *python_symbol_error = true;
+      }
+    }
+    return nullptr;
+  };
+
+  std::string last_error;
+  bool python_symbol_error = false;
+  if (void* handle = try_open_beatrice(last_error, &python_symbol_error)) {
+    return handle;
+  }
+
+  Log("initial Beatrice load failed, python_symbol_error=%d last_error=%s",
+      python_symbol_error, last_error.c_str());
+  if (python_symbol_error) {
+    if (OpenPythonRuntime() != nullptr) {
+      last_error.clear();
+      python_symbol_error = false;
+      if (void* handle = try_open_beatrice(last_error, &python_symbol_error)) {
+        return handle;
+      }
+    }
+  }
+
+  Fail(std::string("failed to load ") + BEATRICE_MAC_RUNTIME_FILENAME +
+       (last_error.empty() ? std::string() : ": " + last_error));
+}
+
+void* Runtime() {
+  static void* handle = OpenRuntime();
+  return handle;
+}
+
+void* Resolve(const char* name) {
+  dlerror();
+  void* symbol = dlsym(Runtime(), name);
+  if (symbol == nullptr) {
+    const char* error = dlerror();
+    Fail(std::string("missing symbol ") + name +
+         (error == nullptr ? std::string() : std::string(": ") + error));
+  }
+  return symbol;
+}
+
+}  // namespace
+
+#define BEATRICE_FORWARD(return_type, name, args, call_args) \
+  return_type name args {                                  \
+    using Fn = return_type(*) args;                         \
+    static auto fn = reinterpret_cast<Fn>(Resolve(#name));  \
+    return fn call_args;                                    \
+  }
+
+extern "C" {
+
+// -------- 20a2 --------
+
+BEATRICE_FORWARD(Beatrice20a2_PhoneExtractor*,
+                 Beatrice20a2_CreatePhoneExtractor, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyPhoneExtractor,
+                 (Beatrice20a2_PhoneExtractor * phone_extractor),
+                 (phone_extractor))
+BEATRICE_FORWARD(Beatrice20a2_PhoneContext1*,
+                 Beatrice20a2_CreatePhoneContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyPhoneContext1,
+                 (Beatrice20a2_PhoneContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20a2_ReadPhoneExtractorParameters,
+                 (Beatrice20a2_PhoneExtractor * phone_extractor,
+                  const char* filename),
+                 (phone_extractor, filename))
+BEATRICE_FORWARD(void, Beatrice20a2_ExtractPhone1,
+                 (const Beatrice20a2_PhoneExtractor* phone_extractor,
+                  const float* input, float* output,
+                  Beatrice20a2_PhoneContext1* ctx),
+                 (phone_extractor, input, output, ctx))
+BEATRICE_FORWARD(Beatrice20a2_PitchEstimator*,
+                 Beatrice20a2_CreatePitchEstimator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyPitchEstimator,
+                 (Beatrice20a2_PitchEstimator * pitch_estimator),
+                 (pitch_estimator))
+BEATRICE_FORWARD(Beatrice20a2_PitchContext1*,
+                 Beatrice20a2_CreatePitchContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyPitchContext1,
+                 (Beatrice20a2_PitchContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20a2_ReadPitchEstimatorParameters,
+                 (Beatrice20a2_PitchEstimator * pitch_estimator,
+                  const char* filename),
+                 (pitch_estimator, filename))
+BEATRICE_FORWARD(void, Beatrice20a2_SetMinQuantizedPitch,
+                 (Beatrice20a2_PitchContext1 * ctx, int min_quantized_pitch),
+                 (ctx, min_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20a2_SetMaxQuantizedPitch,
+                 (Beatrice20a2_PitchContext1 * ctx, int max_quantized_pitch),
+                 (ctx, max_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20a2_EstimatePitch1,
+                 (const Beatrice20a2_PitchEstimator* pitch_estimator,
+                  const float* input, int* output_quantized_pitch,
+                  float* output_pitch_feature, Beatrice20a2_PitchContext1* ctx),
+                 (pitch_estimator, input, output_quantized_pitch,
+                  output_pitch_feature, ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20a2_ReadNSpeakers,
+                 (const char* filename, int* output), (filename, output))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20a2_ReadSpeakerEmbeddings,
+                 (const char* filename, float* output), (filename, output))
+BEATRICE_FORWARD(Beatrice20a2_WaveformGenerator*,
+                 Beatrice20a2_CreateWaveformGenerator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyWaveformGenerator,
+                 (Beatrice20a2_WaveformGenerator * waveform_generator),
+                 (waveform_generator))
+BEATRICE_FORWARD(Beatrice20a2_WaveformContext1*,
+                 Beatrice20a2_CreateWaveformContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20a2_DestroyWaveformContext1,
+                 (Beatrice20a2_WaveformContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20a2_ReadWaveformGeneratorParameters,
+                 (Beatrice20a2_WaveformGenerator * waveform_generator,
+                  const char* filename),
+                 (waveform_generator, filename))
+BEATRICE_FORWARD(void, Beatrice20a2_GenerateWaveform1,
+                 (const Beatrice20a2_WaveformGenerator* waveform_generator,
+                  const float* input_phone, const int* input_quantized_pitch,
+                  const float* input_pitch_features,
+                  const float* input_speaker_embedding, float* output,
+                  Beatrice20a2_WaveformContext1* ctx),
+                 (waveform_generator, input_phone, input_quantized_pitch,
+                  input_pitch_features, input_speaker_embedding, output, ctx))
+
+// -------- 20b1 --------
+
+BEATRICE_FORWARD(Beatrice20b1_PhoneExtractor*,
+                 Beatrice20b1_CreatePhoneExtractor, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyPhoneExtractor,
+                 (Beatrice20b1_PhoneExtractor * phone_extractor),
+                 (phone_extractor))
+BEATRICE_FORWARD(Beatrice20b1_PhoneContext1*,
+                 Beatrice20b1_CreatePhoneContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyPhoneContext1,
+                 (Beatrice20b1_PhoneContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20b1_ReadPhoneExtractorParameters,
+                 (Beatrice20b1_PhoneExtractor * phone_extractor,
+                  const char* filename),
+                 (phone_extractor, filename))
+BEATRICE_FORWARD(void, Beatrice20b1_ExtractPhone1,
+                 (const Beatrice20b1_PhoneExtractor* phone_extractor,
+                  const float* input, float* output,
+                  Beatrice20b1_PhoneContext1* ctx),
+                 (phone_extractor, input, output, ctx))
+BEATRICE_FORWARD(Beatrice20b1_PitchEstimator*,
+                 Beatrice20b1_CreatePitchEstimator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyPitchEstimator,
+                 (Beatrice20b1_PitchEstimator * pitch_estimator),
+                 (pitch_estimator))
+BEATRICE_FORWARD(Beatrice20b1_PitchContext1*,
+                 Beatrice20b1_CreatePitchContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyPitchContext1,
+                 (Beatrice20b1_PitchContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20b1_ReadPitchEstimatorParameters,
+                 (Beatrice20b1_PitchEstimator * pitch_estimator,
+                  const char* filename),
+                 (pitch_estimator, filename))
+BEATRICE_FORWARD(void, Beatrice20b1_SetMinQuantizedPitch,
+                 (Beatrice20b1_PitchContext1 * ctx, int min_quantized_pitch),
+                 (ctx, min_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20b1_SetMaxQuantizedPitch,
+                 (Beatrice20b1_PitchContext1 * ctx, int max_quantized_pitch),
+                 (ctx, max_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20b1_EstimatePitch1,
+                 (const Beatrice20b1_PitchEstimator* pitch_estimator,
+                  const float* input, int* output_quantized_pitch,
+                  float* output_pitch_feature, Beatrice20b1_PitchContext1* ctx),
+                 (pitch_estimator, input, output_quantized_pitch,
+                  output_pitch_feature, ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20b1_ReadNSpeakers,
+                 (const char* filename, int* output), (filename, output))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20b1_ReadSpeakerEmbeddings,
+                 (const char* filename, float* output), (filename, output))
+BEATRICE_FORWARD(Beatrice20b1_WaveformGenerator*,
+                 Beatrice20b1_CreateWaveformGenerator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyWaveformGenerator,
+                 (Beatrice20b1_WaveformGenerator * waveform_generator),
+                 (waveform_generator))
+BEATRICE_FORWARD(Beatrice20b1_WaveformContext1*,
+                 Beatrice20b1_CreateWaveformContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20b1_DestroyWaveformContext1,
+                 (Beatrice20b1_WaveformContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20b1_ReadWaveformGeneratorParameters,
+                 (Beatrice20b1_WaveformGenerator * waveform_generator,
+                  const char* filename),
+                 (waveform_generator, filename))
+BEATRICE_FORWARD(void, Beatrice20b1_GenerateWaveform1,
+                 (const Beatrice20b1_WaveformGenerator* waveform_generator,
+                  const float* input_phone, const int* input_quantized_pitch,
+                  const float* input_pitch_features,
+                  const float* input_speaker_embedding, float* output,
+                  Beatrice20b1_WaveformContext1* ctx),
+                 (waveform_generator, input_phone, input_quantized_pitch,
+                  input_pitch_features, input_speaker_embedding, output, ctx))
+
+// -------- 20rc0 --------
+
+BEATRICE_FORWARD(Beatrice20rc0_PhoneExtractor*,
+                 Beatrice20rc0_CreatePhoneExtractor, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyPhoneExtractor,
+                 (Beatrice20rc0_PhoneExtractor * phone_extractor),
+                 (phone_extractor))
+BEATRICE_FORWARD(Beatrice20rc0_PhoneContext1*,
+                 Beatrice20rc0_CreatePhoneContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyPhoneContext1,
+                 (Beatrice20rc0_PhoneContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20rc0_ReadPhoneExtractorParameters,
+                 (Beatrice20rc0_PhoneExtractor * phone_extractor,
+                  const char* filename),
+                 (phone_extractor, filename))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetVQNumNeighbors,
+                 (Beatrice20rc0_PhoneContext1 * ctx, int num_neighbors),
+                 (ctx, num_neighbors))
+BEATRICE_FORWARD(void, Beatrice20rc0_ExtractPhone1,
+                 (const Beatrice20rc0_PhoneExtractor* phone_extractor,
+                  const float* input, float* output,
+                  Beatrice20rc0_PhoneContext1* ctx),
+                 (phone_extractor, input, output, ctx))
+BEATRICE_FORWARD(Beatrice20rc0_PitchEstimator*,
+                 Beatrice20rc0_CreatePitchEstimator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyPitchEstimator,
+                 (Beatrice20rc0_PitchEstimator * pitch_estimator),
+                 (pitch_estimator))
+BEATRICE_FORWARD(Beatrice20rc0_PitchContext1*,
+                 Beatrice20rc0_CreatePitchContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyPitchContext1,
+                 (Beatrice20rc0_PitchContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20rc0_ReadPitchEstimatorParameters,
+                 (Beatrice20rc0_PitchEstimator * pitch_estimator,
+                  const char* filename),
+                 (pitch_estimator, filename))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetMinQuantizedPitch,
+                 (Beatrice20rc0_PitchContext1 * ctx, int min_quantized_pitch),
+                 (ctx, min_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetMaxQuantizedPitch,
+                 (Beatrice20rc0_PitchContext1 * ctx, int max_quantized_pitch),
+                 (ctx, max_quantized_pitch))
+BEATRICE_FORWARD(void, Beatrice20rc0_EstimatePitch1,
+                 (const Beatrice20rc0_PitchEstimator* pitch_estimator,
+                  const float* input, int* output_quantized_pitch,
+                  float* output_pitch_feature, Beatrice20rc0_PitchContext1* ctx),
+                 (pitch_estimator, input, output_quantized_pitch,
+                  output_pitch_feature, ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20rc0_ReadNSpeakers,
+                 (const char* filename, int* output), (filename, output))
+BEATRICE_FORWARD(Beatrice_ErrorCode, Beatrice20rc0_ReadSpeakerEmbeddings,
+                 (const char* filename, float* output_codebook,
+                  float* output_additive_speaker_embedding,
+                  float* output_formant_shift_embedding,
+                  float* output_key_value_speaker_embedding),
+                 (filename, output_codebook, output_additive_speaker_embedding,
+                  output_formant_shift_embedding,
+                  output_key_value_speaker_embedding))
+BEATRICE_FORWARD(Beatrice20rc0_WaveformGenerator*,
+                 Beatrice20rc0_CreateWaveformGenerator, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyWaveformGenerator,
+                 (Beatrice20rc0_WaveformGenerator * waveform_generator),
+                 (waveform_generator))
+BEATRICE_FORWARD(Beatrice20rc0_WaveformContext1*,
+                 Beatrice20rc0_CreateWaveformContext1, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyWaveformContext1,
+                 (Beatrice20rc0_WaveformContext1 * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20rc0_ReadWaveformGeneratorParameters,
+                 (Beatrice20rc0_WaveformGenerator * waveform_generator,
+                  const char* filename),
+                 (waveform_generator, filename))
+BEATRICE_FORWARD(void, Beatrice20rc0_GenerateWaveform1,
+                 (const Beatrice20rc0_WaveformGenerator* waveform_generator,
+                  const float* input_phone, const int* input_quantized_pitch,
+                  const float* input_pitch_features, float* output,
+                  Beatrice20rc0_WaveformContext1* ctx),
+                 (waveform_generator, input_phone, input_quantized_pitch,
+                  input_pitch_features, output, ctx))
+BEATRICE_FORWARD(Beatrice20rc0_EmbeddingSetter*,
+                 Beatrice20rc0_CreateEmbeddingSetter, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyEmbeddingSetter,
+                 (Beatrice20rc0_EmbeddingSetter * embedding_setter),
+                 (embedding_setter))
+BEATRICE_FORWARD(Beatrice20rc0_EmbeddingContext*,
+                 Beatrice20rc0_CreateEmbeddingContext, (void), ())
+BEATRICE_FORWARD(void, Beatrice20rc0_DestroyEmbeddingContext,
+                 (Beatrice20rc0_EmbeddingContext * ctx), (ctx))
+BEATRICE_FORWARD(Beatrice_ErrorCode,
+                 Beatrice20rc0_ReadEmbeddingSetterParameters,
+                 (Beatrice20rc0_EmbeddingSetter * embedding_setter,
+                  const char* filename),
+                 (embedding_setter, filename))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetCodebook,
+                 (Beatrice20rc0_PhoneContext1 * phone_ctx,
+                  const float* codebook),
+                 (phone_ctx, codebook))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetAdditiveSpeakerEmbedding,
+                 (const Beatrice20rc0_EmbeddingSetter* embedding_setter,
+                  const float* embedding,
+                  Beatrice20rc0_EmbeddingContext* embedding_ctx,
+                  Beatrice20rc0_WaveformContext1* waveform_ctx),
+                 (embedding_setter, embedding, embedding_ctx, waveform_ctx))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetFormantShiftEmbedding,
+                 (const Beatrice20rc0_EmbeddingSetter* embedding_setter,
+                  const float* embedding,
+                  Beatrice20rc0_EmbeddingContext* embedding_ctx,
+                  Beatrice20rc0_WaveformContext1* waveform_ctx),
+                 (embedding_setter, embedding, embedding_ctx, waveform_ctx))
+BEATRICE_FORWARD(void, Beatrice20rc0_RegisterKeyValueSpeakerEmbedding,
+                 (const Beatrice20rc0_EmbeddingSetter* embedding_setter,
+                  const float* kv_speaker_embedding,
+                  Beatrice20rc0_EmbeddingContext* embedding_ctx),
+                 (embedding_setter, kv_speaker_embedding, embedding_ctx))
+BEATRICE_FORWARD(void, Beatrice20rc0_SetKeyValueSpeakerEmbedding,
+                 (const Beatrice20rc0_EmbeddingSetter* embedding_setter,
+                  int block, Beatrice20rc0_EmbeddingContext* embedding_ctx,
+                  Beatrice20rc0_WaveformContext1* waveform_ctx),
+                 (embedding_setter, block, embedding_ctx, waveform_ctx))
+
+}  // extern "C"
+
+#undef BEATRICE_FORWARD

--- a/src/common/parameter_schema.cc
+++ b/src/common/parameter_schema.cc
@@ -360,7 +360,9 @@ const ParameterSchema kSchema = [] {
            })},
       {ParameterID::kVQNumNeighbors,
        NumberParameter(
-           u8"VQ Neighbor Count"s, 0.0, 0.0, 8.0, u8""s, 8, u8"VQNbr"s,
+           u8"VQ Neighbor Count"s, static_cast<double>(kMaxVQNumNeighbors), 0.0,
+           static_cast<double>(kMaxVQNumNeighbors), u8""s, kMaxVQNumNeighbors,
+           u8"VQNbr"s,
            parameter_flag::kCanAutomate,
            [](ControllerCore&, double) { return ErrorCode::kSuccess; },
            [](ProcessorProxy& vc, const double value) {

--- a/src/common/parameter_schema.h
+++ b/src/common/parameter_schema.h
@@ -227,10 +227,13 @@ class ParameterSchema {
                     const ParameterVariant& parameter) {
     parameters_.insert({param_id, parameter});
   }
-  [[nodiscard]] auto GetParameter(const ParameterID param_id) const
-      -> const ParameterVariant& {
-    return parameters_.at(param_id);
-  }
+	  [[nodiscard]] auto GetParameter(const ParameterID param_id) const
+	      -> const ParameterVariant& {
+	    return parameters_.at(param_id);
+	  }
+	  [[nodiscard]] auto Contains(const ParameterID param_id) const -> bool {
+	    return parameters_.contains(param_id);
+	  }
   // NOLINTBEGIN(readability-identifier-naming)
   [[nodiscard]] auto begin() const { return parameters_.begin(); }
   [[nodiscard]] auto end() const { return parameters_.end(); }

--- a/src/common/processor_core.h
+++ b/src/common/processor_core.h
@@ -8,6 +8,8 @@
 
 namespace beatrice::common {
 
+inline constexpr int kMaxVQNumNeighbors = 30;
+
 // 任意のサンプリング周波数と任意のブロックサイズで
 // Beatrice の推論を行う、ミニマルな信号処理クラス。
 // 1 つの子クラスは 1 つのモデルバージョンに対応する。

--- a/src/common/processor_core_2.cc
+++ b/src/common/processor_core_2.cc
@@ -559,7 +559,8 @@ auto ProcessorCore2::SetMaxSourcePitch(const double new_max_source_pitch)
 
 auto ProcessorCore2::SetVQNumNeighbors(const int new_vq_num_neighbors)
     -> ErrorCode {
-  vq_num_neighbors_ = std::clamp(new_vq_num_neighbors, 0, 8);
+  vq_num_neighbors_ =
+      std::clamp(new_vq_num_neighbors, 0, kMaxVQNumNeighbors);
   Beatrice20rc0_SetVQNumNeighbors(phone_context_, vq_num_neighbors_);
   return ErrorCode::kSuccess;
 }

--- a/src/common/resample.h
+++ b/src/common/resample.h
@@ -53,10 +53,11 @@ class Buffer {
   Buffer() = default;
   explicit Buffer(const int siz) { SetSize(siz); }
 
-  void SetSize(const int new_siz) {
-    siz_ = new_siz;
-    data_.resize(new_siz);
-  }
+	  void SetSize(const int new_siz) {
+	    siz_ = new_siz;
+	    data_.resize(new_siz);
+	    data_.reserve(new_siz * 2);
+	  }
 
   void Push(const float value) {
     if (static_cast<int>(data_.size()) >= siz_ * 2) {
@@ -275,9 +276,12 @@ class DownUpSamplerImpl {
 template <class Func>
 class ConvertStreamFunctionFrequency {
   Func function_;
-  double original_frequency_;
-  double target_frequency_;
-  DownUpSamplerImpl down_up_sampler_;
+	  double original_frequency_;
+	  double target_frequency_;
+	  DownUpSamplerImpl down_up_sampler_;
+	  std::vector<float> tmp_vector_;
+	  std::vector<float> converted_input_;
+	  std::vector<float> converted_output_;
 
  public:
   ConvertStreamFunctionFrequency(Func&& function,
@@ -293,23 +297,21 @@ class ConvertStreamFunctionFrequency {
                          normalized_cutoff_freq_in,
                          normalized_cutoff_freq_out) {}
 
-  // input == output であってもよい
-  template <class... Context>
-  auto operator()(const float* const input, float* const output, const int m,
-                  Context&&... context) {
-    auto tmp_vector = std::vector<float>(input, input + m);
-    auto converted_input = std::vector<float>();
-    down_up_sampler_.ResampleIn(tmp_vector, converted_input);
+	  // input == output であってもよい
+	  template <class... Context>
+	  auto operator()(const float* const input, float* const output, const int m,
+	                  Context&&... context) {
+	    tmp_vector_.assign(input, input + m);
+	    down_up_sampler_.ResampleIn(tmp_vector_, converted_input_);
 
-    const auto n = static_cast<int>(converted_input.size());
-    auto converted_output = std::vector<float>(n);
-    function_(std::to_address(converted_input.begin()),
-              std::to_address(converted_output.begin()), n,
-              std::forward<Context>(context)...);
+	    const auto n = static_cast<int>(converted_input_.size());
+	    converted_output_.resize(n);
+	    function_(converted_input_.data(), converted_output_.data(), n,
+	              std::forward<Context>(context)...);
 
-    down_up_sampler_.ResampleOut(converted_output, tmp_vector);
-    std::memcpy(output, std::to_address(tmp_vector.begin()), m * sizeof(float));
-  }
+	    down_up_sampler_.ResampleOut(converted_output_, tmp_vector_);
+	    std::memcpy(output, tmp_vector_.data(), m * sizeof(float));
+	  }
 
   [[nodiscard]] auto IsReady() const -> bool {
     return down_up_sampler_.IsReady();

--- a/src/common/spherical_average.h
+++ b/src/common/spherical_average.h
@@ -48,7 +48,14 @@ class AlignedAllocator {
 
     // allocate aligned memory at N-byte boundaries
     // note that size must be a multiple of N
+#if defined(_MSC_VER)
     void* ptr = _aligned_malloc(size, N);
+#else
+    void* ptr = nullptr;
+    if (posix_memalign(&ptr, N, size) != 0) {
+      ptr = nullptr;
+    }
+#endif
     // throw an exception if memory allocation fails
     if (ptr == nullptr) {
       throw std::bad_alloc();
@@ -57,7 +64,13 @@ class AlignedAllocator {
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void deallocate(T* ptr, std::size_t) noexcept { _aligned_free(ptr); }
+  void deallocate(T* ptr, std::size_t) noexcept {
+#if defined(_MSC_VER)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+  }
 
   template <class U>
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/vst/controls.h
+++ b/src/vst/controls.h
@@ -305,7 +305,15 @@ class FileSelector : public CTextLabel {
           CNewFileSelector::create(getFrame(), CNewFileSelector::kSelectFile);
       if (selector) {
         selector->addFileExtension(CFileExtension("TOML", "toml"));
-        selector->run(this);  // notify に送られる
+        const auto did_run = selector->run(
+            [self = VSTGUI::shared(this)](CNewFileSelector* selector) {
+              if (selector) {
+                self->ApplySelectedFile(*selector);
+              }
+            });
+        if (!did_run) {
+          selector->forget();
+        }
         selector->forget();
       }
       return VSTGUI::kMouseEventHandled;
@@ -316,19 +324,8 @@ class FileSelector : public CTextLabel {
   auto notify(CBaseObject* sender, const char* message)
       -> CMessageResult override {
     if (std::strcmp(message, CNewFileSelector::kSelectEndMessage) == 0) {
-      // ファイルパスを取得
       auto* const selector = static_cast<CNewFileSelector*>(sender);
-      if (const auto* const file_char = selector->getSelectedFile(0)) {
-        const auto file_u8string =
-            std::u8string(file_char, file_char + std::strlen(file_char));
-        const auto file = std::filesystem::path(file_u8string);
-        if (std::filesystem::exists(file) &&
-            std::filesystem::is_regular_file(file)) {
-          SetPath(file);
-          // Editor に通知
-          valueChanged();
-        }
-      }
+      ApplySelectedFile(*selector);
       return kMessageNotified;
     }
     return CTextLabel::notify(sender, message);
@@ -344,6 +341,19 @@ class FileSelector : public CTextLabel {
   auto GetPath() const -> const std::filesystem::path& { return file_; }
 
  private:
+  void ApplySelectedFile(const CNewFileSelector& selector) {
+    if (const auto* const file_char = selector.getSelectedFile(0)) {
+      const auto file_u8string =
+          std::u8string(file_char, file_char + std::strlen(file_char));
+      const auto file = std::filesystem::path(file_u8string);
+      if (std::filesystem::exists(file) &&
+          std::filesystem::is_regular_file(file)) {
+        SetPath(file);
+        valueChanged();
+      }
+    }
+  }
+
   std::filesystem::path file_;
 };
 

--- a/src/vst/editor.cc
+++ b/src/vst/editor.cc
@@ -4,8 +4,6 @@
 
 #include "vst/editor.h"
 
-#include <windows.h>
-
 #include <algorithm>
 #include <cstring>
 #include <limits>

--- a/src/vst/processor.cc
+++ b/src/vst/processor.cc
@@ -119,9 +119,12 @@ auto PLUGIN_API Processor::process(ProcessData& data) -> tresult {
           kResultTrue) {
         continue;
       }
-      unreflected_params_[param_queue->getParameterId()] = value;
-    }
-  }
+	      const auto param_id = param_queue->getParameterId();
+	      if (param_id < unreflected_params_.size()) {
+	        unreflected_params_[param_id] = value;
+	      }
+	    }
+	  }
 
   std::unique_lock<std::mutex> lock(mtx_, std::try_to_lock);
   // ファイルの読み込み中はパラメータ変更の処理を先送りにし、
@@ -137,11 +140,22 @@ auto PLUGIN_API Processor::process(ProcessData& data) -> tresult {
     return kResultTrue;
   }
 
-  for (const auto [vst_param_id, value] : unreflected_params_) {
-    const auto param_id = static_cast<common::ParameterID>(vst_param_id);
-    const auto& param = common::kSchema.GetParameter(param_id);
-    if (const auto* const num_param =
-            std::get_if<common::NumberParameter>(&param)) {
+	  for (size_t vst_param_id = 0; vst_param_id < unreflected_params_.size();
+	       ++vst_param_id) {
+	    const auto maybe_value = unreflected_params_[vst_param_id];
+	    if (!maybe_value.has_value()) {
+	      continue;
+	    }
+	    unreflected_params_[vst_param_id].reset();
+
+	    const auto value = *maybe_value;
+	    const auto param_id = static_cast<common::ParameterID>(vst_param_id);
+	    if (!common::kSchema.Contains(param_id)) {
+	      continue;
+	    }
+	    const auto& param = common::kSchema.GetParameter(param_id);
+	    if (const auto* const num_param =
+	            std::get_if<common::NumberParameter>(&param)) {
       const auto denormalized_value = Denormalize(*num_param, value);
       const auto error_code =
           vc_core_.SetParameter(param_id, denormalized_value);
@@ -153,10 +167,9 @@ auto PLUGIN_API Processor::process(ProcessData& data) -> tresult {
       const auto denormalized_value = Denormalize(*list_param, value);
       const auto error_code =
           vc_core_.SetParameter(param_id, denormalized_value);
-      assert(error_code == common::ErrorCode::kSuccess);
-    }
-  }
-  unreflected_params_.clear();
+	      assert(error_code == common::ErrorCode::kSuccess);
+	    }
+	  }
 
   if (data.numInputs == 0 || data.numOutputs == 0 || data.numSamples == 0) {
     // 何もしない

--- a/src/vst/processor.h
+++ b/src/vst/processor.h
@@ -3,7 +3,9 @@
 #ifndef BEATRICE_VST_PROCESSOR_H_
 #define BEATRICE_VST_PROCESSOR_H_
 
-#include <map>
+#include <array>
+#include <cstddef>
+#include <optional>
 #include <mutex>  // NOLINT(build/c++11)
 
 #include "vst3sdk/pluginterfaces/base/ibstream.h"
@@ -53,11 +55,13 @@ class Processor : public Steinberg::Vst::AudioEffect {
   }
 
  private:
-  std::mutex mtx_;
-  common::ProcessorProxy vc_core_;
-  // メモリ確保が挟まるのが望ましくないが……
-  std::map<ParamID, ParamValue> unreflected_params_;
-};
+	  std::mutex mtx_;
+	  common::ProcessorProxy vc_core_;
+	  static constexpr auto kUnreflectedParamCount =
+	      static_cast<size_t>(common::ParameterID::kSentinel);
+	  std::array<std::optional<ParamValue>, kUnreflectedParamCount>
+	      unreflected_params_;
+	};
 
 }  // namespace beatrice::vst
 

--- a/tools/bench_processor.cc
+++ b/tools/bench_processor.cc
@@ -1,0 +1,481 @@
+// Copyright (c) 2026 Project Beatrice and Contributors
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "beatricelib/beatrice.h"
+#include "common/error.h"
+#include "common/parameter_schema.h"
+#include "common/processor_proxy.h"
+#include "common/resample.h"
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct Options {
+  std::filesystem::path model_path;
+  double sample_rate = 48000.0;
+  int block_size = 480;
+  int iterations = 1000;
+  int warmup = 20;
+  std::string mode = "all";
+};
+
+struct Summary {
+  double avg_ms = 0.0;
+  double p50_ms = 0.0;
+  double p95_ms = 0.0;
+  double p99_ms = 0.0;
+  double max_ms = 0.0;
+};
+
+void PrintUsage(const char* const argv0) {
+  std::cerr
+      << "Usage: " << argv0
+      << " /path/to/model.toml [--sample-rate 48000] [--block-size 480]\n"
+      << "       [--iterations 1000] [--warmup 20]\n"
+      << "       [--mode all|full|runtime|resampler]\n";
+}
+
+auto ParseOptions(const int argc, char** argv, Options& options) -> bool {
+  if (argc < 2) {
+    return false;
+  }
+  options.model_path = argv[1];
+  for (int i = 2; i < argc; ++i) {
+    const auto arg = std::string_view(argv[i]);
+    const auto need_value = [&](const char* const name) -> const char* {
+      if (++i >= argc) {
+        std::cerr << "Missing value for " << name << "\n";
+        return nullptr;
+      }
+      return argv[i];
+    };
+    if (arg == "--sample-rate") {
+      const char* const value = need_value("--sample-rate");
+      if (value == nullptr) return false;
+      options.sample_rate = std::stod(value);
+    } else if (arg == "--block-size") {
+      const char* const value = need_value("--block-size");
+      if (value == nullptr) return false;
+      options.block_size = std::stoi(value);
+    } else if (arg == "--iterations") {
+      const char* const value = need_value("--iterations");
+      if (value == nullptr) return false;
+      options.iterations = std::stoi(value);
+    } else if (arg == "--warmup") {
+      const char* const value = need_value("--warmup");
+      if (value == nullptr) return false;
+      options.warmup = std::stoi(value);
+    } else if (arg == "--mode") {
+      const char* const value = need_value("--mode");
+      if (value == nullptr) return false;
+      options.mode = value;
+    } else {
+      std::cerr << "Unknown argument: " << arg << "\n";
+      return false;
+    }
+  }
+  return !options.model_path.empty() && options.sample_rate > 0.0 &&
+         options.block_size > 0 && options.iterations > 0 &&
+         options.warmup >= 0 &&
+         (options.mode == "all" || options.mode == "full" ||
+          options.mode == "runtime" || options.mode == "resampler");
+}
+
+auto Summarize(std::vector<double> samples_ms) -> Summary {
+  Summary summary;
+  if (samples_ms.empty()) {
+    return summary;
+  }
+  summary.avg_ms =
+      std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0) /
+      static_cast<double>(samples_ms.size());
+  std::sort(samples_ms.begin(), samples_ms.end());
+  const auto pick = [&](const double percentile) {
+    const auto idx = static_cast<size_t>(
+        std::clamp(percentile, 0.0, 1.0) *
+        static_cast<double>(samples_ms.size() - 1));
+    return samples_ms[idx];
+  };
+  summary.p50_ms = pick(0.50);
+  summary.p95_ms = pick(0.95);
+  summary.p99_ms = pick(0.99);
+  summary.max_ms = samples_ms.back();
+  return summary;
+}
+
+void PrintSummary(const std::string_view name, const Summary& summary,
+                  const double budget_ms) {
+  std::cout << name << ": avg=" << summary.avg_ms << "ms"
+            << " p50=" << summary.p50_ms << "ms"
+            << " p95=" << summary.p95_ms << "ms"
+            << " p99=" << summary.p99_ms << "ms"
+            << " max=" << summary.max_ms << "ms"
+            << " budget=" << budget_ms << "ms"
+            << " rt_ratio=" << (summary.avg_ms / budget_ms) << "\n";
+}
+
+void FillInput(std::vector<float>& input, const double sample_rate) {
+  constexpr double kPi = 3.14159265358979323846264338327950288;
+  for (size_t i = 0; i < input.size(); ++i) {
+    const auto t = static_cast<double>(i) / sample_rate;
+    input[i] = static_cast<float>(0.08 * std::sin(2.0 * kPi * 220.0 * t) +
+                                  0.02 * std::sin(2.0 * kPi * 997.0 * t));
+  }
+}
+
+template <class Fn>
+auto MeasureMs(Fn&& fn) -> double {
+  const auto start = Clock::now();
+  fn();
+  const auto end = Clock::now();
+  return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+class RuntimeModel {
+ public:
+  RuntimeModel() = default;
+  RuntimeModel(const RuntimeModel&) = delete;
+  auto operator=(const RuntimeModel&) -> RuntimeModel& = delete;
+
+  ~RuntimeModel() {
+    if (embedding_context_ != nullptr) {
+      Beatrice20rc0_DestroyEmbeddingContext(embedding_context_);
+    }
+    if (waveform_context_ != nullptr) {
+      Beatrice20rc0_DestroyWaveformContext1(waveform_context_);
+    }
+    if (pitch_context_ != nullptr) {
+      Beatrice20rc0_DestroyPitchContext1(pitch_context_);
+    }
+    if (phone_context_ != nullptr) {
+      Beatrice20rc0_DestroyPhoneContext1(phone_context_);
+    }
+    if (embedding_setter_ != nullptr) {
+      Beatrice20rc0_DestroyEmbeddingSetter(embedding_setter_);
+    }
+    if (waveform_generator_ != nullptr) {
+      Beatrice20rc0_DestroyWaveformGenerator(waveform_generator_);
+    }
+    if (pitch_estimator_ != nullptr) {
+      Beatrice20rc0_DestroyPitchEstimator(pitch_estimator_);
+    }
+    if (phone_extractor_ != nullptr) {
+      Beatrice20rc0_DestroyPhoneExtractor(phone_extractor_);
+    }
+  }
+
+  auto Load(const std::filesystem::path& model_path) -> bool {
+    phone_extractor_ = Beatrice20rc0_CreatePhoneExtractor();
+    pitch_estimator_ = Beatrice20rc0_CreatePitchEstimator();
+    waveform_generator_ = Beatrice20rc0_CreateWaveformGenerator();
+    embedding_setter_ = Beatrice20rc0_CreateEmbeddingSetter();
+    phone_context_ = Beatrice20rc0_CreatePhoneContext1();
+    pitch_context_ = Beatrice20rc0_CreatePitchContext1();
+    waveform_context_ = Beatrice20rc0_CreateWaveformContext1();
+    embedding_context_ = Beatrice20rc0_CreateEmbeddingContext();
+    if (phone_extractor_ == nullptr || pitch_estimator_ == nullptr ||
+        waveform_generator_ == nullptr || embedding_setter_ == nullptr ||
+        phone_context_ == nullptr || pitch_context_ == nullptr ||
+        waveform_context_ == nullptr || embedding_context_ == nullptr) {
+      std::cerr << "Runtime create failed\n";
+      return false;
+    }
+
+    const auto dir = model_path.parent_path();
+    const auto as_utf8 = [](const std::filesystem::path& path) {
+      return path.u8string();
+    };
+    const auto phone_bin = as_utf8(dir / "phone_extractor.bin");
+    const auto pitch_bin = as_utf8(dir / "pitch_estimator.bin");
+    const auto waveform_bin = as_utf8(dir / "waveform_generator.bin");
+    const auto embedding_bin = as_utf8(dir / "embedding_setter.bin");
+    const auto speaker_bin = as_utf8(dir / "speaker_embeddings.bin");
+
+    const auto cstr = [](const std::u8string& value) {
+      return reinterpret_cast<const char*>(value.c_str());
+    };
+    if (Beatrice20rc0_ReadPhoneExtractorParameters(phone_extractor_,
+                                                   cstr(phone_bin)) !=
+        Beatrice_kSuccess) {
+      std::cerr << "ReadPhoneExtractorParameters failed\n";
+      return false;
+    }
+    if (Beatrice20rc0_ReadPitchEstimatorParameters(pitch_estimator_,
+                                                   cstr(pitch_bin)) !=
+        Beatrice_kSuccess) {
+      std::cerr << "ReadPitchEstimatorParameters failed\n";
+      return false;
+    }
+    if (Beatrice20rc0_ReadWaveformGeneratorParameters(waveform_generator_,
+                                                      cstr(waveform_bin)) !=
+        Beatrice_kSuccess) {
+      std::cerr << "ReadWaveformGeneratorParameters failed\n";
+      return false;
+    }
+    if (Beatrice20rc0_ReadEmbeddingSetterParameters(embedding_setter_,
+                                                    cstr(embedding_bin)) !=
+        Beatrice_kSuccess) {
+      std::cerr << "ReadEmbeddingSetterParameters failed\n";
+      return false;
+    }
+    if (Beatrice20rc0_ReadNSpeakers(cstr(speaker_bin), &n_speakers_) !=
+        Beatrice_kSuccess) {
+      std::cerr << "ReadNSpeakers failed\n";
+      return false;
+    }
+
+    codebooks_.resize((n_speakers_ + 1) * BEATRICE_20RC0_CODEBOOK_SIZE *
+                      BEATRICE_20RC0_PHONE_CHANNELS);
+    additive_speaker_embeddings_.resize(
+        (n_speakers_ + 1) * BEATRICE_WAVEFORM_GENERATOR_HIDDEN_CHANNELS);
+    formant_shift_embeddings_.resize(
+        9 * BEATRICE_WAVEFORM_GENERATOR_HIDDEN_CHANNELS);
+    key_value_speaker_embeddings_.resize(
+        (n_speakers_ + 1) * BEATRICE_20RC0_KV_LENGTH *
+        BEATRICE_20RC0_KV_SPEAKER_EMBEDDING_CHANNELS);
+    if (Beatrice20rc0_ReadSpeakerEmbeddings(
+            cstr(speaker_bin), codebooks_.data(),
+            additive_speaker_embeddings_.data(),
+            formant_shift_embeddings_.data(),
+            key_value_speaker_embeddings_.data()) != Beatrice_kSuccess) {
+      std::cerr << "ReadSpeakerEmbeddings failed\n";
+      return false;
+    }
+
+    Beatrice20rc0_SetCodebook(phone_context_, codebooks_.data());
+    Beatrice20rc0_SetAdditiveSpeakerEmbedding(
+        embedding_setter_, additive_speaker_embeddings_.data(),
+        embedding_context_, waveform_context_);
+    Beatrice20rc0_SetFormantShiftEmbedding(
+        embedding_setter_,
+        formant_shift_embeddings_.data() +
+            4 * BEATRICE_WAVEFORM_GENERATOR_HIDDEN_CHANNELS,
+        embedding_context_, waveform_context_);
+    Beatrice20rc0_RegisterKeyValueSpeakerEmbedding(
+        embedding_setter_, key_value_speaker_embeddings_.data(),
+        embedding_context_);
+    for (int block = 0; block < BEATRICE_20RC0_N_BLOCKS; ++block) {
+      Beatrice20rc0_SetKeyValueSpeakerEmbedding(
+          embedding_setter_, block, embedding_context_, waveform_context_);
+    }
+    return true;
+  }
+
+  void Process(const float* const input, float* const output,
+               double* const phone_ms, double* const pitch_ms,
+               double* const waveform_ms) {
+    *phone_ms = MeasureMs([&] {
+      Beatrice20rc0_ExtractPhone1(phone_extractor_, input, phone_.data(),
+                                  phone_context_);
+    });
+    *pitch_ms = MeasureMs([&] {
+      Beatrice20rc0_EstimatePitch1(pitch_estimator_, input, &quantized_pitch_,
+                                   pitch_feature_.data(), pitch_context_);
+    });
+    *waveform_ms = MeasureMs([&] {
+      Beatrice20rc0_GenerateWaveform1(
+          waveform_generator_, phone_.data(), &quantized_pitch_,
+          pitch_feature_.data(), output, waveform_context_);
+    });
+  }
+
+ private:
+  Beatrice20rc0_PhoneExtractor* phone_extractor_ = nullptr;
+  Beatrice20rc0_PitchEstimator* pitch_estimator_ = nullptr;
+  Beatrice20rc0_WaveformGenerator* waveform_generator_ = nullptr;
+  Beatrice20rc0_EmbeddingSetter* embedding_setter_ = nullptr;
+  Beatrice20rc0_PhoneContext1* phone_context_ = nullptr;
+  Beatrice20rc0_PitchContext1* pitch_context_ = nullptr;
+  Beatrice20rc0_WaveformContext1* waveform_context_ = nullptr;
+  Beatrice20rc0_EmbeddingContext* embedding_context_ = nullptr;
+  int n_speakers_ = 0;
+  std::vector<float> codebooks_;
+  std::vector<float> additive_speaker_embeddings_;
+  std::vector<float> formant_shift_embeddings_;
+  std::vector<float> key_value_speaker_embeddings_;
+  std::array<float, BEATRICE_20RC0_PHONE_CHANNELS> phone_{};
+  std::array<float, 4> pitch_feature_{};
+  int quantized_pitch_ = 0;
+};
+
+auto RunFullProcessorBench(const Options& options) -> bool {
+  beatrice::common::ProcessorProxy processor(beatrice::common::kSchema);
+  if (const auto err = processor.SetSampleRate(options.sample_rate);
+      err != beatrice::common::ErrorCode::kSuccess) {
+    std::cerr << "SetSampleRate failed: " << static_cast<int>(err) << "\n";
+    return false;
+  }
+  if (const auto err = processor.LoadModel(options.model_path);
+      err != beatrice::common::ErrorCode::kSuccess) {
+    std::cerr << "LoadModel failed: " << static_cast<int>(err) << "\n";
+    return false;
+  }
+
+  std::vector<float> input(options.block_size);
+  std::vector<float> buffer(options.block_size);
+  FillInput(input, options.sample_rate);
+
+  for (int i = 0; i < options.warmup; ++i) {
+    std::copy(input.begin(), input.end(), buffer.begin());
+    [[maybe_unused]] const auto err =
+        processor.GetCore()->Process(buffer.data(), buffer.data(),
+                                     options.block_size);
+  }
+
+  std::vector<double> samples_ms;
+  samples_ms.reserve(options.iterations);
+  for (int i = 0; i < options.iterations; ++i) {
+    std::copy(input.begin(), input.end(), buffer.begin());
+    samples_ms.push_back(MeasureMs([&] {
+      [[maybe_unused]] const auto err =
+          processor.GetCore()->Process(buffer.data(), buffer.data(),
+                                       options.block_size);
+    }));
+  }
+
+  const auto budget_ms =
+      static_cast<double>(options.block_size) / options.sample_rate * 1000.0;
+  PrintSummary("full_processor", Summarize(std::move(samples_ms)), budget_ms);
+  return true;
+}
+
+struct FakeModelBlock {
+  void operator()(const float* const input, float* const output) const {
+    for (int i = 0; i < BEATRICE_OUT_HOP_LENGTH; ++i) {
+      output[i] =
+          input[std::min(BEATRICE_IN_HOP_LENGTH - 1,
+                         i * BEATRICE_IN_HOP_LENGTH / BEATRICE_OUT_HOP_LENGTH)];
+    }
+  }
+};
+
+auto RunResamplerBench(const Options& options) -> bool {
+  beatrice::resampler::AnyFreqInOut<FakeModelBlock> processor(
+      options.sample_rate);
+  if (!processor.IsReady()) {
+    std::cerr << "Resampler is not ready\n";
+    return false;
+  }
+
+  std::vector<float> input(options.block_size);
+  std::vector<float> output(options.block_size);
+  FillInput(input, options.sample_rate);
+
+  for (int i = 0; i < options.warmup; ++i) {
+    processor(input.data(), output.data(), options.block_size);
+  }
+
+  std::vector<double> samples_ms;
+  samples_ms.reserve(options.iterations);
+  for (int i = 0; i < options.iterations; ++i) {
+    samples_ms.push_back(MeasureMs([&] {
+      processor(input.data(), output.data(), options.block_size);
+    }));
+  }
+
+  const auto budget_ms =
+      static_cast<double>(options.block_size) / options.sample_rate * 1000.0;
+  PrintSummary("resampler_adapter", Summarize(std::move(samples_ms)),
+               budget_ms);
+  return true;
+}
+
+auto RunRuntimeBench(const Options& options) -> bool {
+  RuntimeModel runtime;
+  if (!runtime.Load(options.model_path)) {
+    return false;
+  }
+
+  std::array<float, BEATRICE_IN_HOP_LENGTH> input{};
+  std::array<float, BEATRICE_OUT_HOP_LENGTH> output{};
+  std::vector<float> input_vector(input.size());
+  FillInput(input_vector, 16000.0);
+  std::copy(input_vector.begin(), input_vector.end(), input.begin());
+
+  for (int i = 0; i < options.warmup; ++i) {
+    double phone_ms = 0.0;
+    double pitch_ms = 0.0;
+    double waveform_ms = 0.0;
+    runtime.Process(input.data(), output.data(), &phone_ms, &pitch_ms,
+                    &waveform_ms);
+  }
+
+  std::vector<double> phone_samples_ms;
+  std::vector<double> pitch_samples_ms;
+  std::vector<double> waveform_samples_ms;
+  std::vector<double> total_samples_ms;
+  phone_samples_ms.reserve(options.iterations);
+  pitch_samples_ms.reserve(options.iterations);
+  waveform_samples_ms.reserve(options.iterations);
+  total_samples_ms.reserve(options.iterations);
+  for (int i = 0; i < options.iterations; ++i) {
+    double phone_ms = 0.0;
+    double pitch_ms = 0.0;
+    double waveform_ms = 0.0;
+    runtime.Process(input.data(), output.data(), &phone_ms, &pitch_ms,
+                    &waveform_ms);
+    phone_samples_ms.push_back(phone_ms);
+    pitch_samples_ms.push_back(pitch_ms);
+    waveform_samples_ms.push_back(waveform_ms);
+    total_samples_ms.push_back(phone_ms + pitch_ms + waveform_ms);
+  }
+
+  constexpr double kRuntimeBudgetMs = 10.0;
+  PrintSummary("runtime_phone", Summarize(std::move(phone_samples_ms)),
+               kRuntimeBudgetMs);
+  PrintSummary("runtime_pitch", Summarize(std::move(pitch_samples_ms)),
+               kRuntimeBudgetMs);
+  PrintSummary("runtime_waveform", Summarize(std::move(waveform_samples_ms)),
+               kRuntimeBudgetMs);
+  PrintSummary("runtime_total", Summarize(std::move(total_samples_ms)),
+               kRuntimeBudgetMs);
+  return true;
+}
+
+}  // namespace
+
+auto main(const int argc, char** argv) -> int {
+  Options options;
+  if (!ParseOptions(argc, argv, options)) {
+    PrintUsage(argv[0]);
+    return 64;
+  }
+  if (!std::filesystem::exists(options.model_path)) {
+    std::cerr << "Model file does not exist: " << options.model_path << "\n";
+    return 66;
+  }
+
+  std::cout << "model=" << options.model_path << "\n"
+            << "sample_rate=" << options.sample_rate << "\n"
+            << "block_size=" << options.block_size << "\n"
+            << "iterations=" << options.iterations << "\n"
+            << "warmup=" << options.warmup << "\n";
+
+  if (options.mode == "all" || options.mode == "runtime") {
+    if (!RunRuntimeBench(options)) {
+      return 1;
+    }
+  }
+  if (options.mode == "all" || options.mode == "resampler") {
+    if (!RunResamplerBench(options)) {
+      return 1;
+    }
+  }
+  if (options.mode == "all" || options.mode == "full") {
+    if (!RunFullProcessorBench(options)) {
+      return 1;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Windows 専用の `lib/beatricelib/beatrice.lib` を使えない macOS でも VST3 をビルドできるようにする変更です。

`beatrice.h` の C ABI を受けて起動時に `dlopen` で Beatrice ランタイム (VCClient mac 配布物に含まれる `beatrice_v20rc0.abi3.so` 等) を読み込む小さな転送層 (`src/common/beatricelib_dynamic_loader.cc`) を追加しました。ランタイム本体のパスは `BEATRICE_MAC_RUNTIME` で渡してもらい、CMake が `Contents/Resources/beatrice/` に複製して ad-hoc サインします。再配布許諾の都合で、ランタイム本体はこの PR には含めていません。

ほかに `BEATRICE_ENABLE_AUV2` (AUv2 ラッパの足場、default OFF)、`BEATRICE_ENABLE_LOADER_LOG`、`BEATRICE_ENABLE_BENCHMARKS` の CMake オプションを追加しています。AUv2 については最新の Xcode + clang だと数か所つまずく箇所が残っているので、有効化までに必要な fix は別 PR で出させてください。

手元で動作確認できているランタイムが arm64 のみなので、現状 Apple Silicon 限定です。Windows 側は `if(SMTG_WIN)` / `elseif(APPLE)` で分岐していて挙動は変えていないつもりですが、Windows 環境が手元にないので merge 前に念のためご確認いただけると助かります。